### PR TITLE
Fixes IMC error message from forestry:

### DIFF
--- a/mods/natura/common/NContent.java
+++ b/mods/natura/common/NContent.java
@@ -670,7 +670,7 @@ public class NContent implements IFuelHandler
 		StringBuilder builder = new StringBuilder();
 		String string = builder.append("farmWheat@").append(seeds.itemID).append(".0.").append(crops.blockID).append(".3").toString();
 		FMLInterModComms.sendMessage("Forestry", "add-farmable-crop", string);
-		StringBuilder builder = new StringBuilder();
+		builder = new StringBuilder();
 		string = builder.append("farmWheat@").append(seeds.itemID).append(".1.").append(crops.blockID).append(".8").toString();
 		FMLInterModComms.sendMessage("Forestry", "add-farmable-crop", string);
 		


### PR DESCRIPTION
Fixes error message from forestry:

```
2013-06-14 02:54:57 [INFO] [Forestry] Received an invalid 'add-farmable-crop' request 'farmWheat@12659.0.3260.3farmWheat@12659.1.3260.8' from mod Natura.
```
