### PR TITLE
Registered Barley with Thaumcraft

### DIFF
--- a/src/mods/natura/common/NContent.java
+++ b/src/mods/natura/common/NContent.java
@@ -1062,6 +1062,7 @@ public class NContent implements IFuelHandler
         FMLInterModComms.sendMessage("Thaumcraft", "harvestClickableCrop", new ItemStack(netherBerryBush, 1, 14));
         FMLInterModComms.sendMessage("Thaumcraft", "harvestClickableCrop", new ItemStack(netherBerryBush, 1, 15));
         FMLInterModComms.sendMessage("Thaumcraft", "harvestClickableCrop", new ItemStack(crops, 1, 8));
+        FMLInterModComms.sendMessage("Thaumcraft", "harvestStandardCrop", new ItemStack(crops, 1, 3));
 
         //Forestry
         StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
Added a line to register Barley as a Standard Crop to be harvested by golems in Thaumcraft.
