### PR TITLE
Fix flour smelting into bread with a different damage value

### DIFF
--- a/src/main/java/mods/natura/common/NContent.java
+++ b/src/main/java/mods/natura/common/NContent.java
@@ -793,7 +793,7 @@ public class NContent implements IFuelHandler
 
         for (int i = 1; i <= 2; i++)
         {
-            FurnaceRecipes.smelting().func_151394_a(new ItemStack(plantItem, 1, i), new ItemStack(Items.bread, 1, 1), 0.5f);
+            FurnaceRecipes.smelting().func_151394_a(new ItemStack(plantItem, 1, i), new ItemStack(Items.bread, 1), 0.5f);
             GameRegistry.addRecipe(new ItemStack(Items.cake, 1), "AAA", "BEB", " C ", 'A', Items.milk_bucket, 'B', Items.sugar, 'C', new ItemStack(plantItem, 1, i), 'E', Items.egg);
         }
 


### PR DESCRIPTION
See title. When flour is smelted it creates bread with damage value 1. There doesn't seem to be any particular reason for this (correct me if I'm wrong), so I fixed it.
