### PR TITLE
Remove log spam when opening the mod's workbenches

### DIFF
--- a/src/main/java/mods/natura/blocks/overrides/AlternateWorkbench.java
+++ b/src/main/java/mods/natura/blocks/overrides/AlternateWorkbench.java
@@ -86,7 +86,6 @@ public class AlternateWorkbench extends BlockWorkbench
         }
         else
         {
-            System.out.println("Workbench");
             player.openGui(Natura.instance, NGuiHandler.craftingGui, world, x, y, z);
             //player.displayGUIWorkbench(par2, par3, par4);
             return true;


### PR DESCRIPTION
Removes the "Workbench" log message whenever someone opens a workbench, which can get quite spammy on servers.
