### PR TITLE
Fix some berry/cactus generation checks.

### DIFF
--- a/src/main/java/mods/natura/worldgen/BerryBushGen.java
+++ b/src/main/java/mods/natura/worldgen/BerryBushGen.java
@@ -123,7 +123,7 @@ public class BerryBushGen extends WorldGenerator
         do
         {
             block = world.getBlock(x, y, z);
-            if (block != null && !block.isLeaves(world, x, y, z))
+            if (!world.isAirBlock(x, y, z) && !block.isLeaves(world, x, y, z))
             {
                 break;
             }

--- a/src/main/java/mods/natura/worldgen/NetherBerryBushGen.java
+++ b/src/main/java/mods/natura/worldgen/NetherBerryBushGen.java
@@ -47,7 +47,7 @@ public class NetherBerryBushGen extends WorldGenerator
     {
         int returnHeight = -1;
         Block blockID = world.getBlock(x, y - 1, z);
-        if (blockID != null && !world.getBlock(x, y, z).isOpaqueCube() && (blockID == Blocks.netherrack || blockID.canSustainPlant(world, x, y - 1, z, ForgeDirection.UP, (IPlantable) blockGen)))
+        if (!world.isAirBlock(x, y - 1, z) && !world.getBlock(x, y, z).isOpaqueCube() && (blockID == Blocks.netherrack || blockID.canSustainPlant(world, x, y - 1, z, ForgeDirection.UP, (IPlantable) blockGen)))
         {
             //System.out.println("Returning "+y);
             return y;
@@ -57,7 +57,7 @@ public class NetherBerryBushGen extends WorldGenerator
         do
         {
             Block bID = world.getBlock(x, height, z);
-            if (bID != null)
+            if (!world.isAirBlock(x, height, z))
             {
                 if (bID == Blocks.netherrack || bID.canSustainPlant(world, x, height, z, ForgeDirection.UP, (IPlantable) blockGen))
                 {
@@ -128,7 +128,7 @@ public class NetherBerryBushGen extends WorldGenerator
         do
         {
             block = world.getBlock(x, y, z);
-            if (block != null && !block.isLeaves(world, x, y, z))
+            if (!world.isAirBlock(x, y, z) && !block.isLeaves(world, x, y, z))
             {
                 break;
             }

--- a/src/main/java/mods/natura/worldgen/SaguaroGen.java
+++ b/src/main/java/mods/natura/worldgen/SaguaroGen.java
@@ -26,7 +26,7 @@ public class SaguaroGen extends WorldGenerator
     {
         int yPos = findGround(world, x, y, z, useHeight);
         Block currentID = world.getBlock(x, yPos, z);
-        if (currentID != null)
+        if (!world.isAirBlock(x, yPos, z))
         {
             if (currentID == NContent.saguaro)
             {
@@ -151,7 +151,7 @@ public class SaguaroGen extends WorldGenerator
         {
             height--;
             Block underID = world.getBlock(x, height, z);
-            if (underID == Blocks.dirt || underID == Blocks.grass || height < PHNatura.seaLevel)
+            if (underID == Blocks.sand || underID == Blocks.dirt || underID == Blocks.grass || height < PHNatura.seaLevel)
                 foundGround = true;
         } while (!foundGround);
         return height + 1;


### PR DESCRIPTION
world.getBlock no longer returns null when it finds air blocks, this changes those into world.isAirBlock checks.
Saguaro cactus was also not generating in most of the desert because sand wasn't a valid "ground" block.
