### PR TITLE
Configurable Seed Bags

### DIFF
--- a/src/main/java/mods/natura/common/NContent.java
+++ b/src/main/java/mods/natura/common/NContent.java
@@ -159,6 +159,8 @@ public class NContent implements IFuelHandler
         waterDrop = new CactusJuice(false).setUnlocalizedName("waterdrop");
         GameRegistry.registerItem(waterDrop, "waterdrop");
 
+        if (PHNatura.enableSeedBags)
+        {
         wheatBag = new SeedBag(Blocks.wheat, 0, "wheat").setUnlocalizedName("wheatBag");
         GameRegistry.registerItem(wheatBag, "wheatBag");
         GameRegistry.registerCustomItemStack("bagWheat", new ItemStack(wheatBag, 1, 0));
@@ -177,6 +179,8 @@ public class NContent implements IFuelHandler
         cottonBag = new SeedBag(crops, 4, "cotton").setUnlocalizedName("cottonBag");
         GameRegistry.registerItem(cottonBag, "cottonBag");
         GameRegistry.registerCustomItemStack("bagCotton", new ItemStack(cottonBag, 1, 0));
+        }
+
         boneBag = new BoneBag("bone").setUnlocalizedName("boneBag");
         GameRegistry.registerItem(boneBag, "boneBag");
         GameRegistry.registerCustomItemStack("bagBone", new ItemStack(boneBag, 1, 0));
@@ -759,6 +763,8 @@ public class NContent implements IFuelHandler
     public void addRecipes ()
     {
         //Crops
+        if (PHNatura.enableSeedBags)
+        {
         GameRegistry.addRecipe(new ItemStack(wheatBag, 1, 0), "sss", "sss", "sss", 's', Items.wheat_seeds);
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(barleyBag, 1, 0), "sss", "sss", "sss", 's', "seedBarley"));
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(potatoBag, 1, 0), "sss", "sss", "sss", 's', "cropPotato"));
@@ -774,6 +780,7 @@ public class NContent implements IFuelHandler
         GameRegistry.addRecipe(new ItemStack(Items.nether_wart, 9, 0), "s", 's', netherWartBag);
         GameRegistry.addRecipe(new ItemStack(seeds, 9, 1), "s", 's', cottonBag);
         GameRegistry.addRecipe(new ItemStack(Items.dye, 9, 15), "s", 's', boneBag);
+        }
 
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Items.string), "sss", 's', "cropCotton"));
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Blocks.wool), "sss", "sss", "sss", 's', "cropCotton"));

--- a/src/main/java/mods/natura/common/PHNatura.java
+++ b/src/main/java/mods/natura/common/PHNatura.java
@@ -75,6 +75,7 @@ public class PHNatura
         generateGlowshroomtree = config.get("Disabler", "Generate Glowshroom Trees", true).getBoolean(true);
         dropCotton = config.get("Disabler", "Drop cotton seeds from grass", true).getBoolean(true);
         dropBarley = config.get("Disabler", "Drop barley seeds from grass", true).getBoolean(true);
+        enableSeedBags = config.get("Disabler", "Enable Seed Bags", true).getBoolean(true);
         try
         {
             Class.forName("chococraft.common.ModChocoCraft");
@@ -170,11 +171,6 @@ public class PHNatura
     public static boolean generateSkyberries;
     public static boolean generateStingberries;
 
-    public static boolean generateGreenglowshroom;
-    public static boolean generatePurpleglowshroom;
-    public static boolean generateBlueglowshroom;
-    public static boolean generateGlowshroomtree;
-
     public static int saguaroSpawnRarity;
 
     public static int raspSpawnRarity;
@@ -199,6 +195,11 @@ public class PHNatura
 
     //Clouds
 
+    public static boolean generateOverworldClouds;
+    public static boolean generateSulfurClouds;
+    public static boolean generateAshClouds;
+    public static boolean generateDarkClouds;
+
     public static int cloudSpawnRarity;
     public static int cloudSpawnHeight;
     public static int cloudSpawnRange;
@@ -211,6 +212,12 @@ public class PHNatura
     public static int ashSpawnRarity;
     public static int ashSpawnHeight;
     public static int ashSpawnRange;
+
+    //Glowshrooms
+	
+    public static boolean generateGreenglowshroom;
+    public static boolean generatePurpleglowshroom;
+    public static boolean generateBlueglowshroom;
 
     //Trees
 
@@ -230,19 +237,9 @@ public class PHNatura
 
     public static boolean generateDarkwood;
     public static boolean generateFusewood;
+    public static boolean generateGlowshroomtree;
 
     public static boolean generateThornvines;
-
-    public static boolean generateOverworldClouds;
-    public static boolean generateSulfurClouds;
-    public static boolean generateAshClouds;
-    public static boolean generateDarkClouds;
-    public static boolean enableWheatRecipe;
-    public static boolean dropBarley;
-    public static boolean dropCotton;
-
-    public static boolean overrideNether;
-    public static boolean canRespawnInNether;
 
     public static int redwoodSpawnRarity;
     public static int bloodSpawnRarity;
@@ -260,6 +257,16 @@ public class PHNatura
     public static int willowRarity;
     public static int tigerRarity;
     public static int silverbellRarity;
+
+    //Other
+
+    public static boolean enableSeedBags;
+    public static boolean enableWheatRecipe;
+    public static boolean dropBarley;
+    public static boolean dropCotton;
+
+    public static boolean overrideNether;
+    public static boolean canRespawnInNether;
 
     public static int babyHeatscarMinimum;
     public static int babyHeatscarMaximum;

--- a/src/main/java/mods/natura/items/SeedBag.java
+++ b/src/main/java/mods/natura/items/SeedBag.java
@@ -3,6 +3,7 @@ package mods.natura.items;
 import java.util.List;
 
 import mods.natura.common.NaturaTab;
+import mods.natura.common.PHNatura;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
@@ -27,7 +28,7 @@ public class SeedBag extends Item
         crop = block;
         cropMetadata = cMD;
         textureName = texture;
-        this.setCreativeTab(NaturaTab.tab);
+        this.setCreativeTab(PHNatura.enableSeedBags ? NaturaTab.tab : null);
     }
 
     @Override


### PR DESCRIPTION
Bone bag, however, is always enabled since it's used for Creative tab icon and I dunno how to fix this. But it's uncraftable at least.
Closes #243
