### PR TITLE
Optmiized Leave Decay Check

### DIFF
--- a/src/main/java/mods/natura/worldgen/EucalyptusTreeGenShort.java
+++ b/src/main/java/mods/natura/worldgen/EucalyptusTreeGenShort.java
@@ -22,8 +22,7 @@ public class EucalyptusTreeGenShort extends WorldGenerator
     public boolean generate (World world, Random random, int x, int y, int z)
     {
         int height = findGround(world, x, y, z);
-        generateRandomTree(world, random, x, height, z);
-        return true;
+		return generateRandomTree(world, random, x, height, z);
     }
 
     int findGround (World world, int x, int y, int z)


### PR DESCRIPTION
... by caching the LOG-Search result.

The optimization caches the Log-Block Position and tries to re-use this position for each block update.

Reduces the CPU Time Consumed a lot (in my case 7 Redwood Trees + Eucalyptus were permanently loaded by chunkloaders, near to my base)
