### PR TITLE
Fix for Eucalyptus Tree Generation when using Bonemeal

### DIFF
--- a/src/main/java/mods/natura/worldgen/EucalyptusTreeGenShort.java
+++ b/src/main/java/mods/natura/worldgen/EucalyptusTreeGenShort.java
@@ -22,8 +22,7 @@ public class EucalyptusTreeGenShort extends WorldGenerator
     public boolean generate (World world, Random random, int x, int y, int z)
     {
         int height = findGround(world, x, y, z);
-        generateRandomTree(world, random, x, height, z);
-        return true;
+        return generateRandomTree(world, random, x, height, z);
     }
 
     int findGround (World world, int x, int y, int z)


### PR DESCRIPTION
When using bonemeal on an eucalyptus sapling whith a impossible-to-grow environment (height blocked) the Sapling just disappeared.

This is a fix for this odd behavior.

