### PR TITLE
Fixes Bookshelfs dropping books without texture

### DIFF
--- a/src/main/java/com/progwml6/natura/decorative/block/bookshelves/BlockNetherBookshelves.java
+++ b/src/main/java/com/progwml6/natura/decorative/block/bookshelves/BlockNetherBookshelves.java
@@ -1,28 +1,25 @@
 package com.progwml6.natura.decorative.block.bookshelves;
 
-import java.util.Random;
-
-import javax.annotation.Nullable;
-
 import com.progwml6.natura.library.NaturaRegistry;
 import com.progwml6.natura.nether.block.planks.BlockNetherPlanks;
-
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Items;
-import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import slimeknights.mantle.block.EnumBlock;
 
-public class BlockNetherBookshelves extends EnumBlock<BlockNetherPlanks.PlankType>
-{
+import java.util.ArrayList;
+import java.util.List;
+
+public class BlockNetherBookshelves extends EnumBlock<BlockNetherPlanks.PlankType> {
     public static PropertyEnum<BlockNetherPlanks.PlankType> TYPE = PropertyEnum.create("type", BlockNetherPlanks.PlankType.class);
 
-    public BlockNetherBookshelves()
-    {
+    public BlockNetherBookshelves() {
         super(Material.WOOD, TYPE, BlockNetherPlanks.PlankType.class);
 
         this.setSoundType(SoundType.WOOD);
@@ -30,35 +27,18 @@ public class BlockNetherBookshelves extends EnumBlock<BlockNetherPlanks.PlankTyp
         this.setCreativeTab(NaturaRegistry.tabDecorative);
     }
 
-    /**
-     * Returns the quantity of items to drop on block destruction.
-     */
-    @Override
-    public int quantityDropped(Random random)
-    {
-        return 3;
-    }
 
-    /**
-     * Get the Item that this Block should drop when harvested.
-     */
     @Override
-    @Nullable
-    public Item getItemDropped(IBlockState state, Random rand, int fortune)
-    {
-        return Items.BOOK;
+    public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune) {
+        List<ItemStack> drops =  new ArrayList<>();
+        drops.add(new ItemStack(Items.BOOK, 3));
+        return drops;
     }
 
     @Override
-    public float getEnchantPowerBonus(World world, BlockPos pos)
-    {
+    public float getEnchantPowerBonus(World world, BlockPos pos) {
         return 1;
     }
 
-    @Override
-    @Deprecated
-    public boolean isFullCube(IBlockState state)
-    {
-        return false;
-    }
+
 }

--- a/src/main/java/com/progwml6/natura/decorative/block/bookshelves/BlockOverworldBookshelves.java
+++ b/src/main/java/com/progwml6/natura/decorative/block/bookshelves/BlockOverworldBookshelves.java
@@ -1,21 +1,20 @@
 package com.progwml6.natura.decorative.block.bookshelves;
 
-import java.util.Random;
-
-import javax.annotation.Nullable;
-
 import com.progwml6.natura.library.NaturaRegistry;
 import com.progwml6.natura.overworld.block.planks.BlockOverworldPlanks;
-
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Items;
-import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import slimeknights.mantle.block.EnumBlock;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class BlockOverworldBookshelves extends EnumBlock<BlockOverworldPlanks.PlankType>
 {
@@ -30,35 +29,16 @@ public class BlockOverworldBookshelves extends EnumBlock<BlockOverworldPlanks.Pl
         this.setCreativeTab(NaturaRegistry.tabDecorative);
     }
 
-    /**
-     * Returns the quantity of items to drop on block destruction.
-     */
     @Override
-    public int quantityDropped(Random random)
-    {
-        return 3;
-    }
-
-    /**
-     * Get the Item that this Block should drop when harvested.
-     */
-    @Override
-    @Nullable
-    public Item getItemDropped(IBlockState state, Random rand, int fortune)
-    {
-        return Items.BOOK;
+    public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune) {
+        List<ItemStack> drops =  new ArrayList<>();
+        drops.add(new ItemStack(Items.BOOK, 3));
+        return drops;
     }
 
     @Override
     public float getEnchantPowerBonus(World world, BlockPos pos)
     {
         return 1;
-    }
-
-    @Override
-    @Deprecated
-    public boolean isFullCube(IBlockState state)
-    {
-        return false;
     }
 }


### PR DESCRIPTION
Otherwise the books look like that:
![image](https://cloud.githubusercontent.com/assets/8137062/26026563/f2ec2ee2-37fd-11e7-84f3-2b138c08bfbb.png)

This fix might be needed on the 1.11 branch as well